### PR TITLE
feat(common) : GlobalExcetpionHandler 구현

### DIFF
--- a/src/main/java/com/sideproject/withpt/common/exception/ErrorCode.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.sideproject.withpt.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    TEST_ERROR(HttpStatus.BAD_REQUEST, "테스트 에러 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/sideproject/withpt/common/exception/GlobalException.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/GlobalException.java
@@ -1,0 +1,19 @@
+package com.sideproject.withpt.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GlobalException extends RuntimeException {
+
+    public static final GlobalException TEST_ERROR = new GlobalException(ErrorCode.TEST_ERROR);
+
+    private final ErrorCode errorCode;
+
+    // 의도적인 예외이므로 stack trace 제거(불필요한 예외처리 비용 제거)
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/com/sideproject/withpt/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.sideproject.withpt.common.exception;
+
+import com.sideproject.withpt.common.response.ApiErrorResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    protected ResponseEntity<ApiErrorResponse> handleGlobalException(GlobalException e, HttpServletRequest request) {
+        return handleExceptionInternal(e.getErrorCode(), request);
+    }
+
+    private ResponseEntity<ApiErrorResponse> handleExceptionInternal(ErrorCode errorCode, HttpServletRequest request) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiErrorResponse.from(errorCode, request));
+    }
+
+}

--- a/src/main/java/com/sideproject/withpt/common/response/ApiErrorResponse.java
+++ b/src/main/java/com/sideproject/withpt/common/response/ApiErrorResponse.java
@@ -1,0 +1,28 @@
+package com.sideproject.withpt.common.response;
+
+import com.sideproject.withpt.common.exception.ErrorCode;
+import javax.servlet.http.HttpServletRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ApiErrorResponse {
+
+    private final String status;
+    private final String code;
+    private final String message;
+    private final String requestUrl;
+
+    public static ApiErrorResponse from(ErrorCode errorCode, HttpServletRequest request) {
+        return ApiErrorResponse.builder()
+            .status(errorCode.getHttpStatus().toString())
+            .code(errorCode.name())
+            .message(errorCode.getMessage())
+            .requestUrl(request.getRequestURI())
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 변경사항
- 테스트 결과 아래와 같은 형식으로 에러 메세지를 응답합니다.
![image](https://github.com/dieter-project/WithPT-BE/assets/53173850/3eebee46-d993-436e-924c-cca6a45dbe6c)
- 스프링이 제공하는 ResponseEntityExceptionHandler을 이용해 추후 parameter valid 와 같은 @ExceptionHandler 에 대한 커스텀을 하지 않고 이미 제공하는 메소드를 사용할 수 있도록 구현
-  예외 생성 비용 절약을 위해 stack trace 제거(불필요한 예외처리 비용 제거)


</br>

## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?
    - postman으로 테스트 대체

</br>

## 관련 이슈
- #1 
</br>

## 참고 자료 
- https://meetup.nhncloud.com/posts/47
- https://s-y-130.tistory.com/203
