### PR TITLE
feat(common) : @Valid 유효성 검사 및 Enum 타입 유효성 검사

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,15 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // 스프링 시큐리티
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/sideproject/withpt/application/type/DietType.java
+++ b/src/main/java/com/sideproject/withpt/application/type/DietType.java
@@ -1,0 +1,9 @@
+package com.sideproject.withpt.application.type;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sideproject.withpt.common.exception.validator.CustomEnumDeserializer;
+
+@JsonDeserialize(using = CustomEnumDeserializer.class)
+public enum DietType {
+    GENERAL, FAT_LOSS, BULK_UP;
+}

--- a/src/main/java/com/sideproject/withpt/application/type/Gender.java
+++ b/src/main/java/com/sideproject/withpt/application/type/Gender.java
@@ -1,0 +1,9 @@
+package com.sideproject.withpt.application.type;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sideproject.withpt.common.exception.validator.CustomEnumDeserializer;
+
+@JsonDeserialize(using = CustomEnumDeserializer.class)
+public enum Gender {
+    MAN, WOMAN
+}

--- a/src/main/java/com/sideproject/withpt/application/type/OAuthProvider.java
+++ b/src/main/java/com/sideproject/withpt/application/type/OAuthProvider.java
@@ -1,0 +1,9 @@
+package com.sideproject.withpt.application.type;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sideproject.withpt.common.exception.validator.CustomEnumDeserializer;
+
+@JsonDeserialize(using = CustomEnumDeserializer.class)
+public enum OAuthProvider {
+    GOOGLE, KAKAO
+}

--- a/src/main/java/com/sideproject/withpt/application/type/Role.java
+++ b/src/main/java/com/sideproject/withpt/application/type/Role.java
@@ -1,0 +1,9 @@
+package com.sideproject.withpt.application.type;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sideproject.withpt.common.exception.validator.CustomEnumDeserializer;
+
+@JsonDeserialize(using = CustomEnumDeserializer.class)
+public enum Role {
+    GUEST, USER
+}

--- a/src/main/java/com/sideproject/withpt/common/exception/ErrorCode.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/ErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    TEST_ERROR(HttpStatus.BAD_REQUEST, "테스트 에러 입니다.");
+    TEST_ERROR(HttpStatus.BAD_REQUEST, "테스트 에러 입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네입입니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/sideproject/withpt/common/exception/GlobalException.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/GlobalException.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 public class GlobalException extends RuntimeException {
 
     public static final GlobalException TEST_ERROR = new GlobalException(ErrorCode.TEST_ERROR);
+    public static final GlobalException DUPLICATE_NICKNAME = new GlobalException(ErrorCode.DUPLICATE_NICKNAME);
+    public static final GlobalException INVALID_PARAMETER = new GlobalException(ErrorCode.INVALID_PARAMETER);
 
     private final ErrorCode errorCode;
 

--- a/src/main/java/com/sideproject/withpt/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/GlobalExceptionHandler.java
@@ -2,23 +2,64 @@ package com.sideproject.withpt.common.exception;
 
 import com.sideproject.withpt.common.response.ApiErrorResponse;
 import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(GlobalException.class)
-    protected ResponseEntity<ApiErrorResponse> handleGlobalException(GlobalException e, HttpServletRequest request) {
+    protected ResponseEntity<Object> handleGlobalException(GlobalException e, HttpServletRequest request) {
+        log.warn("handleGlobalException", e);
         return handleExceptionInternal(e.getErrorCode(), request);
     }
 
-    private ResponseEntity<ApiErrorResponse> handleExceptionInternal(ErrorCode errorCode, HttpServletRequest request) {
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e, HttpServletRequest request) {
+        log.warn("handleIllegalArgument", e);
+        ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage(), request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException ex,
+        HttpHeaders headers,
+        HttpStatus status,
+        WebRequest request)
+    {
+        log.warn("handleMethodArgumentNotValid", ex);
+        ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(ex, errorCode, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, HttpServletRequest request) {
         return ResponseEntity
             .status(errorCode.getHttpStatus())
             .body(ApiErrorResponse.from(errorCode, request));
     }
+
+    private ResponseEntity<Object> handleExceptionInternal(BindException e, ErrorCode errorCode, WebRequest request) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiErrorResponse.from(e, errorCode, request));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message, HttpServletRequest request) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiErrorResponse.from(errorCode, message, request));
+    }
+
+
 
 }

--- a/src/main/java/com/sideproject/withpt/common/exception/validator/CustomEnumDeserializer.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/validator/CustomEnumDeserializer.java
@@ -1,0 +1,31 @@
+package com.sideproject.withpt.common.exception.validator;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomEnumDeserializer <T extends Enum<T>> extends JsonDeserializer<T> {
+
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        final String value = p.getValueAsString();
+        final Class<?> dtoClass = p.getCurrentValue().getClass();
+        final String fieldName = p.currentName();
+
+        try {
+            final Class<T> enumClass = getEnumClass(dtoClass, fieldName);
+            return Enum.valueOf(enumClass, value);
+        } catch (IllegalArgumentException | NoSuchFieldException e) {
+            return null;
+        }
+    }
+
+    private static <T extends Enum<T>> Class<T> getEnumClass(Class<?> dtoClass, String fieldName) throws NoSuchFieldException {
+        Field field = dtoClass.getDeclaredField(fieldName);
+        return (Class<T>) field.getType();
+    }
+}

--- a/src/main/java/com/sideproject/withpt/common/exception/validator/EnumValidator.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/validator/EnumValidator.java
@@ -1,0 +1,35 @@
+package com.sideproject.withpt.common.exception.validator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum<?>> {
+
+    private List<Object> enumValues;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        enumValues = Stream.of(constraintAnnotation.enumClass().getEnumConstants())
+            .map(Enum::name)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isValid(Enum<?> value, ConstraintValidatorContext context) {
+        log.info("request value : {}", value);
+        return isNotNull(value) && isContainsValue(value);
+    }
+
+    private boolean isContainsValue(Enum<?> value) {
+        return enumValues.contains(value.name());
+    }
+
+    private boolean isNotNull(Enum<?> value) {
+        return value != null;
+    }
+}

--- a/src/main/java/com/sideproject/withpt/common/exception/validator/ValidEnum.java
+++ b/src/main/java/com/sideproject/withpt/common/exception/validator/ValidEnum.java
@@ -1,0 +1,31 @@
+package com.sideproject.withpt.common.exception.validator;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {EnumValidator.class})
+public @interface ValidEnum {
+    String regexp() default "";
+
+    Class<? extends Enum<?>> enumClass();
+
+    String message() default "해당 필드의 타입에서 지원하지 않는 값입니다. {regexp}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/sideproject/withpt/common/response/ApiErrorResponse.java
+++ b/src/main/java/com/sideproject/withpt/common/response/ApiErrorResponse.java
@@ -1,10 +1,19 @@
 package com.sideproject.withpt.common.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sideproject.withpt.common.exception.ErrorCode;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
 
 @Getter
 @Builder
@@ -16,11 +25,56 @@ public class ApiErrorResponse {
     private final String message;
     private final String requestUrl;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ValidationError{
+
+        private String field;
+        private String message;
+
+        public static ValidationError of(final FieldError fieldError){
+            return ValidationError.builder()
+                .field(fieldError.getField())
+                .message(fieldError.getDefaultMessage())
+                .build();
+        }
+    }
+
     public static ApiErrorResponse from(ErrorCode errorCode, HttpServletRequest request) {
         return ApiErrorResponse.builder()
             .status(errorCode.getHttpStatus().toString())
             .code(errorCode.name())
             .message(errorCode.getMessage())
+            .requestUrl(request.getRequestURI())
+            .build();
+    }
+
+    public static ApiErrorResponse from(BindException e, ErrorCode errorCode, WebRequest request) {
+        List<ApiErrorResponse.ValidationError> validationErrorList = e.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .map(ApiErrorResponse.ValidationError::of)
+            .collect(Collectors.toList());
+
+        return ApiErrorResponse.builder()
+            .status(errorCode.getHttpStatus().toString())
+            .code(errorCode.name())
+            .message(errorCode.getMessage())
+            .errors(validationErrorList)
+            .requestUrl(((ServletWebRequest)request).getRequest().getRequestURI())
+            .build();
+    }
+
+    public static ApiErrorResponse from(ErrorCode errorCode, String message, HttpServletRequest request) {
+        return ApiErrorResponse.builder()
+            .status(errorCode.getHttpStatus().toString())
+            .code(errorCode.name())
+            .message(message)
             .requestUrl(request.getRequestURI())
             .build();
     }


### PR DESCRIPTION
## 변경사항
- @Valid 유효성 검사 시 에러 메시지 구체화
![image](https://github.com/dieter-project/WithPT-BE/assets/53173850/7ea6a954-4040-4209-902d-fdaa23681229)

</br>

- Enum 타입을 Json 객체에서 자바 객체로 매핑 시 JSON parse error 발생
   - JSON parse error는 javax.validation 의 유효성 검사 이전에 발생하기 때문에 예외 핸들링 불가 
   - @JsonCreator으로 Json -> 자바 객체 "역직렬화" 시 각 Enum 객체에 생성자 생성으로 해결 가능
      - but) Enum 타입 마다 매번 생성자를 생성해주는 번거로움
   - Reflection API 을 통해 DTO의 클래스와 필드의 이름으로 enum의 클래스를 가져온 뒤 유효성 검사


## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?

</br>

## 관련 이슈
- #8 

</br>

## 참고 자료
- https://www.baeldung.com/javax-validations-enums
- https://codinghejow.tistory.com/371
- https://cchoimin.tistory.com/entry/Enum-%EC%9C%A0%ED%9A%A8%EC%84%B1-%EA%B2%80%EC%82%AC%ED%95%98%EA%B8%B0
- https://charliezip.tistory.com/13
