### PR TITLE
토큰 재발급 필터 로직 수정

### DIFF
--- a/src/main/java/com/sideproject/withpt/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sideproject/withpt/common/jwt/JwtAuthenticationFilter.java
@@ -46,6 +46,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String token = this.resolveTokenFromRequest(request);
 
+            if(request.getRequestURI().equals("/api/v1/oauth/reissue")){
+                filterChain.doFilter(request, response);
+            }
+
             if (StringUtils.hasText(token) && this.jwtTokenProvider.isValidationToken(token)) {
 
                 if (ObjectUtils.isEmpty(redisClient.get(ACCESS_TOKEN_BLACK_LIST_PREFIX + token))) {
@@ -55,10 +59,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     // SecurityContext 에 Authentication 객체를 저장
                     SecurityContextHolder.getContext().setAuthentication(authentication);
 
-                    log.info(
-                        String.format("[%s] -> %s", this.jwtTokenProvider.extractSubject(token),
-                            request.getRequestURI())
-                    );
+                    log.info(String.format("[%s] -> %s", this.jwtTokenProvider.extractSubject(token), request.getRequestURI()));
                 } else {
                     log.error("Access Black-List Token: {}", NOT_VERIFICATION_LOGOUT.getMessage());
                     request.setAttribute("exception", NOT_VERIFICATION_LOGOUT.getMessage());

--- a/src/main/java/com/sideproject/withpt/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sideproject/withpt/common/jwt/JwtTokenProvider.java
@@ -93,7 +93,6 @@ public class JwtTokenProvider {
         }
     }
 
-    //    public boolean isValidationToken(String token, HttpServletRequest request) {
     public boolean isValidationToken(String token) {
         return !Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().isEmpty();
     }

--- a/src/main/java/com/sideproject/withpt/common/jwt/entrypoint/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sideproject/withpt/common/jwt/entrypoint/JwtAuthenticationEntryPoint.java
@@ -28,6 +28,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException) throws IOException, ServletException {
 
+        if(request.getRequestURI().equals("/api/v1/oauth/reissue")){
+            return;
+        }
+
         String exception = (String) request.getAttribute("exception");
 
         if (exception.equals(CREDENTIALS_DO_NOT_EXIST.getMessage())) {


### PR DESCRIPTION
## 변경사항

token이 만료 돼서 reissue를 하는건데 reissue에도 token이 만료됐다기보다는 다른 응답이 필요
그리고 reissue에서도 다른 api 요청 token 만료와 동일한 응답이 오면 프론트 쪽에서는 구분할 수가 없어서 계속 무한루프 문제 발생

따라서 reissue의 경우 토큰 유무만 판단하고 필터를 거치지 않도록 수정


## 체크 리스트 (Checklist)

pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

- [x]  master 브랜치가 아니라 **develop** 브랜치에 Merge하도록 pull request를 작성 중이신가요?
- [x]  모든 **테스트**가 성공했나요?
